### PR TITLE
Release grpc api client

### DIFF
--- a/.changeset/clean-files-know.md
+++ b/.changeset/clean-files-know.md
@@ -1,0 +1,6 @@
+---
+"@xmtp/grpc-api-client": patch
+"@xmtp/bot-kit-pro": patch
+---
+
+Move logging down a level

--- a/packages/grpc-api-client/src/GrpcApiClient.ts
+++ b/packages/grpc-api-client/src/GrpcApiClient.ts
@@ -239,7 +239,7 @@ export default class GrpcApiClient implements ApiClient {
           await stream
         } catch (e) {
           if (isAbortError(e as RpcError)) {
-            this.logger.info({ contentTopics }, "aborting stream")
+            this.logger.debug({ contentTopics }, "aborting stream")
             return
           }
           if (new Date().getTime() - startTime.getTime() < 1000) {
@@ -255,7 +255,7 @@ export default class GrpcApiClient implements ApiClient {
 
     return {
       unsubscribe: async () => {
-        this.logger.info("unsubscribing")
+        this.logger.debug("unsubscribing")
         abortController.abort()
         await stream.requests.complete()
       },


### PR DESCRIPTION
## Summary

- Moves logging to `debug` level for some normal operations
- Forces a release of some unreleased changes to `grpc-api-client`